### PR TITLE
Undo Gary Fung's enablement of self-signed SSL

### DIFF
--- a/ImageCacheManager.js
+++ b/ImageCacheManager.js
@@ -10,10 +10,10 @@ module.exports = (defaultOptions = {}, urlCache = MemoryCache, fs = fsUtils, pat
 
     const defaultDefaultOptions = {
         headers: {},
-        ttl: 3600 * 24 * 30,   // 60 * 60 * 24 * 14, // 2 weeks
+        ttl: 3600 * 24 * 30,   // 4 weeks
         useQueryParamsInCacheKey: false,
         cacheLocation: fs.getCacheDir(),
-        allowSelfSignedSSL: true,   // false,
+        allowSelfSignedSSL: false,
     };
 
     // apply default options


### PR DESCRIPTION
We've forked from Gary Fung's version of this library and disabled self-signed SSL, as the original library did. We should only enable self-signed SSL in dev environments, and only that if it becomes necessary.